### PR TITLE
Fix lambda function handling in phase 2 ast tree walk, Improve ignore file support, and clean up dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | Traditional SAST can’t “see” how you build prompts, stream completions or store vectors. | Lintai walks your AST, tags every AI sink (OpenAI, Anthropic, LangChain, …), follows wrapper functions and asks LLMs to judge the risk. |
 
-> **Requires Python 3.9 or newer**
+> **Requires Python 3.10 or newer**
 
 ---
 
@@ -43,9 +43,10 @@ To enable LLM-backed checks:
 pip install "lintai[openai]"      # or  [anthropic]  [gemini]  [cohere]
 ```
 
-### 2. Set up keys
+### 2. Set up environment
 
-Use a `.env` file (see `env.sample`) or export the vars.
+Use a `.env` file (see `env.sample`) or export the vars to pass LLM model and key
+Create a `.lintaiignore` to tell the tools which directories or files to ignore in the codebase (see `lintaiignore.sample`)
 
 ### 3. Run it
 

--- a/lintai/cli_support.py
+++ b/lintai/cli_support.py
@@ -25,13 +25,22 @@ _NOISY_HTTP_LOGGERS = (
 for n in _NOISY_HTTP_LOGGERS:
     logging.getLogger(n).setLevel(logging.WARNING)
 
+
 # ------------------------------------------------------------------ utils
-if Path(".lintaiignore").exists():
-    _IGNORE = pathspec.PathSpec.from_lines(
-        "gitwildmatch", Path(".lintaiignore").read_text().splitlines()
-    )
-else:
-    _IGNORE = pathspec.PathSpec.from_lines("gitwildmatch", [])
+def _load_ignore() -> pathspec.PathSpec:
+    for candidate in (".lintaiignore", ".gitignore"):
+        p = Path(candidate)
+        if p.is_file():
+            logger.info("Loading ignore patterns from %s", p)
+            return pathspec.PathSpec.from_lines(
+                "gitwildmatch", p.read_text().splitlines()
+            )
+    # no ignore files – empty spec
+    logger.info("No .lintaiignore or .gitignore found. Will not ignore any files.")
+    return pathspec.PathSpec.from_lines("gitwildmatch", [])
+
+
+_IGNORE = _load_ignore()
 
 
 def iter_python_files(root: Path) -> Iterable[Path]:

--- a/lintai/engine/ai_call_analysis.py
+++ b/lintai/engine/ai_call_analysis.py
@@ -460,7 +460,12 @@ class ProjectAnalyzer:
                     self._units_by_node[node] = unit
                     self._id_to_qname[id(node)] = q
                     self._qname_to_id[q] = id(node)
-                    plain = f"{self._modnames[unit.path]}.{node.name}"
+                    # Lambdas are anonymous – they have no `.name` attribute.
+                    if hasattr(node, "name"):
+                        plain = f"{self._modnames[unit.path]}.{node.name}"
+                    else:  # ast.Lambda → give it a synthetic, lineno-based label
+                        plain = f"{self._modnames[unit.path]}.<lambda>@{getattr(node, 'lineno', 0)}"
+
                     self._qname_to_id.setdefault(plain, id(node))
                     self._graph.add_node(id(node))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "lintai"
 version = "0.0.1"
 description = "Shift-left LLM security scanner"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Harsh Parandekar", email = "harsh.parandekar@paskl.ai" }]
 license = { text = "Apache-2.0" }
 readme = "README.md"
@@ -21,6 +21,7 @@ dependencies = [
     "pyyaml>=6.0",
     "networkx>=3.2",
     "python-dotenv>=1.0",
+    "pathspec",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,9 @@ black
 typer>=0.12
 pyyaml
 python-dotenv
+pathspec
 networkx
+
 # Dependencies for LLM providers used in the library
 openai>=1.0
 anthropic


### PR DESCRIPTION
Summary of Changes:
✅ Switched required Python version to >=3.10 in pyproject.toml and README

✅ Added fallback support for .gitignore in addition to .lintaiignore

✅ Made pathspec an explicit dependency (was missing in some envs despite usage)

✅ Fixed edge case in ai_call_analysis.py where lambda functions (AST nodes without .name) caused errors — now gracefully labeled as <lambda>@<lineno>

✅ Clarified README instructions on environment setup and ignore file usage

✅ Synced requirements-dev.txt with actual dependencies (pathspec)
