### PR TITLE
Fix pytest and add pre-commit hook for test validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,10 @@ repos:
     hooks:
       - id: black
         args: [--check]
+  - repo: local
+    hooks:
+      - id: run-pytest
+        name: Run Pytest
+        entry: pytest
+        language: system
+        pass_filenames: false

--- a/examples/hello_world_ai.py
+++ b/examples/hello_world_ai.py
@@ -10,3 +10,16 @@ user_input = input("Say something: ")
 prompt = f"Please answer the user: {user_input}"
 resp = openai.ChatCompletion.create(model="gpt-4o", prompt=prompt)
 eval(resp)
+
+
+def test_dsl_rule_hits(tmp_path):
+    code = 'secret = "hunter2"\nprompt = f"My password is {secret}"\n'
+    src = tmp_path / "leak.py"
+    src.write_text(code)
+
+    result = subprocess.run(
+        ["lintai", "scan", str(tmp_path), "--ruleset", str(ROOT / "lintai/dsl/rules")],
+        env=dict(os.environ, LINTAI_LLM_PROVIDER="dummy"),
+        capture_output=True,
+        text=True,
+    )

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -5,12 +5,25 @@ ROOT = pathlib.Path(__file__).parents[1]
 
 
 def test_dsl_rule_hits(tmp_path):
-    code = 'secret = "hunter2"\nprompt = f"My password is {secret}"\n'
+    code = (
+        'secret = "hunter2"\n'
+        'prompt = f"My password is {secret}"\n'
+        "import openai\n"
+        'openai.ChatCompletion.create(model="dummy", messages=[{"role": "user", "content": prompt}])\n'
+    )
     src = tmp_path / "leak.py"
     src.write_text(code)
 
     result = subprocess.run(
-        ["lintai", "scan", str(tmp_path), "--ruleset", str(ROOT / "lintai/dsl/rules")],
+        [
+            "lintai",
+            "scan",
+            str(tmp_path),
+            "--ruleset",
+            str(ROOT / "lintai/dsl/rules"),
+            "--log-level",
+            "DEBUG",
+        ],
         env=dict(os.environ, LINTAI_LLM_PROVIDER="dummy"),
         capture_output=True,
         text=True,
@@ -23,5 +36,8 @@ def test_dsl_rule_hits(tmp_path):
         findings = json.loads(result.stdout)
     except Exception as e:
         pytest.fail(f"Could not parse JSON from output:\n{result.stdout}\nError: {e}")
+
+    print("STDOUT:\n", result.stdout)
+    print("STDERR:\n", result.stderr)
 
     assert any(f["owasp_id"] == "A02" for f in findings)


### PR DESCRIPTION
✅ Fixes broken  by ensuring a dummy AI sink is present in the test input.

✅ Adds ============================= test session starts ==============================
platform darwin -- Python 3.13.0, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/harshparandekar/dev/security/lintai-llm-detectors
configfile: pyproject.toml
plugins: anyio-4.9.0
collected 8 items

tests/test_cli.py .                                                      [ 12%]
tests/test_core.py .                                                     [ 25%]
tests/test_dsl.py .                                                      [ 37%]
tests/test_env_loader.py .                                               [ 50%]
tests/test_llm_detector.py .                                             [ 62%]
tests/test_llm_provider.py ...                                           [100%]

============================== 8 passed in 0.70s =============================== as a local hook in  to automatically run tests before committing.

This improves reliability and ensures regressions are caught earlier during development.