### PR TITLE
Add LLM usage budget feature with request/token/cost limits

### DIFF
--- a/env.sample
+++ b/env.sample
@@ -3,6 +3,16 @@
 ###############################################
 
 # -------------------------------------------------
+# 0) Set budget constraints for tool's LLM usage
+# -------------------------------------------------
+# Total prompt+completion
+LINTAI_MAX_LLM_TOKENS=50000
+# Hard $ cap
+LINTAI_MAX_LLM_COST_USD=10.00
+# Runaway llm use safety-valve
+LINTAI_MAX_LLM_REQUESTS=500
+
+# -------------------------------------------------
 # 1) Select provider (openai | azure | anthropic | gemini | cohere | dummy)
 # -------------------------------------------------
 LINTAI_LLM_PROVIDER=openai

--- a/lintai/core/report.py
+++ b/lintai/core/report.py
@@ -1,8 +1,27 @@
+# lintai/core/report.py
 import json
+import sys
 from pathlib import Path
-from typing import List
+from typing import List, Any, Optional
 from lintai.core.finding import Finding
+from lintai.llm.budget import manager as _budget
 
 
-def to_json(findings: List[Finding], out: Path):
-    out.write_text(json.dumps([f.to_dict() for f in findings], indent=2))
+def write_scan_report(findings: List[Finding], out: Optional[Path]):
+    report = {
+        "llm_usage": _budget.snapshot(),
+        "findings": [f.to_dict() for f in findings],
+    }
+    json_str = json.dumps(report, indent=2)
+    if out:
+        out.write_text(json_str)
+    else:
+        print(json_str)
+
+
+def write_inventory_report(inventory: List[dict[str, Any]], out: Optional[Path]):
+    json_str = json.dumps(inventory, indent=2)
+    if out:
+        out.write_text(json_str)
+    else:
+        print(json_str)

--- a/lintai/detectors/llm_code_audit.py
+++ b/lintai/detectors/llm_code_audit.py
@@ -377,7 +377,7 @@ def llm_audit(unit):
     try:
         reply = _CLIENT.ask(prompt, max_tokens=180)
     except Exception as exc:
-        logger.debug("llm_code_audit: provider error %s – skipped", exc)
+        logger.error("llm_code_audit: provider error %s – skipped", exc)
         return
 
     payload = _json_fragment(reply)

--- a/lintai/llm/azure.py
+++ b/lintai/llm/azure.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 import json, os, importlib.util, types
 from lintai.llm.base import LLMClient
+from lintai.llm.token_util import estimate_tokens
+from lintai.llm.errors import BudgetExceededError
 
 _spec = importlib.util.find_spec("openai")
 openai: types.ModuleType | None = importlib.import_module("openai") if _spec else None
@@ -37,16 +39,36 @@ class _AzureClient(LLMClient):
         # deployment name, not model family
         self.model = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 
-    def ask(self, prompt: str, **kw) -> str:
+    def ask(self, prompt: str, max_tokens: int = 256, **kw) -> str:
         try:
+            # ①  budget check
+            self._preflight_budget(prompt, max_tokens)
+
+            # ②  call provider and get response
             resp = self.client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
-                max_tokens=kw.get("max_tokens", 256),
+                max_tokens=max_tokens,
                 temperature=kw.get("temperature", 0.2),
                 response_format={"type": "json_object"},
             )
+
+            # ③  extract usage for *real* accounting
+            usage = getattr(resp, "usage", None)
+            completion_tok = (
+                usage.completion_tokens
+                if usage
+                else estimate_tokens(resp.choices[0].message.content, self.model)
+            )
+            cost_usd = None  # OpenAI API v2 doesn’t return cost – leave None
+
+            # ④  commit to budget
+            self._post_commit_budget(completion_tok, cost_usd)
+
+            # ⑤  return the message content
             return resp.choices[0].message.content
+        except BudgetExceededError:
+            raise
         except Exception as exc:
             return json.dumps(
                 {

--- a/lintai/llm/base.py
+++ b/lintai/llm/base.py
@@ -1,21 +1,69 @@
+# lintai/llm/base.py
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
+from decimal import Decimal
+import logging
+from lintai.llm.budget import manager as _budget
+from lintai.llm.token_util import estimate_tokens
+from lintai.llm.errors import BudgetExceededError
 
-# Define constant at module level
-DEFAULT_MAX_CONTEXT_SIZE = 8192
+DEFAULT_MAX_CONTEXT_SIZE = 8192  # fallback for providers that don’t expose this
+
+logger = logging.getLogger(__name__)
 
 
 class LLMClient(ABC):
     """
     Minimal interface all providers must implement.
+    Sub-classes automatically inherit budget / quota enforcement.
     """
 
     is_dummy: bool = False  # real providers don’t touch it
+    model: str = "unknown"  # override in concrete subclasses
 
-    @abstractmethod
-    def ask(self, prompt: str, **kwargs: Any) -> str: ...
-
+    # ------------------------------------------------------------------ #
+    # public helpers                                                     #
+    # ------------------------------------------------------------------ #
     @property
-    def max_context(self) -> int:
+    def max_context(self) -> int:  # pragma: no cover
+        """Override if provider exposes the real value."""
         return DEFAULT_MAX_CONTEXT_SIZE
+
+    # ------------------------------------------------------------------ #
+    # convenience: subclasses call this *before* the network roundtrip   #
+    # ------------------------------------------------------------------ #
+    def _preflight_budget(self, prompt: str, max_completion: int) -> None:
+        prompt_tok = estimate_tokens(prompt, self.model)
+        if not _budget.allow(prompt_tok, max_completion, self.model):
+            raise BudgetExceededError(
+                "LLM budget exceeded – set higher limits via "
+                "LINTAI_MAX_LLM_* environment variables if needed."
+            )
+        # store for post-commit
+        self._tmp_prompt_tok = prompt_tok
+        self._tmp_max_completion = max_completion
+
+    def _post_commit_budget(self, completion_tok: int, real_cost: float | None):
+        _budget.commit(
+            self._tmp_prompt_tok,
+            completion_tok,
+            self.model,
+            None if real_cost is None else Decimal(str(real_cost)),
+        )
+        logger.debug(
+            "Budget commit: prompt=%s, completion=%s, model=%s, usd=%s",
+            self._tmp_prompt_tok,
+            completion_tok,
+            self.model,
+            real_cost,
+        )
+
+        # clean-up
+        del self._tmp_prompt_tok, self._tmp_max_completion
+
+    # ------------------------------------------------------------------ #
+    # abstract interface – provider must call *_budget helpers           #
+    # ------------------------------------------------------------------ #
+    @abstractmethod
+    def ask(self, prompt: str, max_tokens: int, **kwargs: Any) -> str: ...

--- a/lintai/llm/budget.py
+++ b/lintai/llm/budget.py
@@ -1,0 +1,127 @@
+# lintai/llm/budget.py
+from __future__ import annotations
+import os, threading
+from contextlib import contextmanager
+from decimal import Decimal
+from typing import Optional, Final
+
+# --------------------------------------------------------------------------- #
+# helper: price table  (USD / 1000 tok)                                        #
+# --------------------------------------------------------------------------- #
+# Keep this coarse - we only need an order-of-magnitude estimate.
+# You can override/extend via env LINTAI_PRICE_TABLE=json
+_DEFAULT_PRICES: Final[dict[str, Decimal]] = {
+    "gpt-4o": Decimal("0.005"),
+    "gpt-4": Decimal("0.03"),
+    "gpt-3.5": Decimal("0.001"),
+    "claude-3": Decimal("0.008"),
+    "claude-2": Decimal("0.008"),
+    "gemini": Decimal("0.001"),
+    "command-r": Decimal("0.002"),  # Cohere
+}
+
+# --------------------------------------------------------------------------- #
+# helpers                                                                     #
+# --------------------------------------------------------------------------- #
+
+_KILO = Decimal("1000")  # one place only
+
+
+def _usd_for_tokens(tokens: int, model: str) -> Decimal:
+    """
+    Convert *tokens* to a *Decimal* USD cost for *model* using the price table.
+    Keeps all math in `Decimal` to avoid float/Decimal TypeErrors.
+    """
+    return (Decimal(tokens) / _KILO) * _price_for(model)
+
+
+def _price_for(model: str) -> Decimal:
+    model = model.lower()
+    for prefix, usd in _DEFAULT_PRICES.items():
+        if model.startswith(prefix):
+            return usd
+    return Decimal("0.002")  # safe default
+
+
+# --------------------------------------------------------------------------- #
+# main manager                                                                 #
+# --------------------------------------------------------------------------- #
+class BudgetManager:
+    """
+    Thread-safe singleton that tracks tokens / cost / request count **for the
+    whole Lintai run**. Limits are configurable via environment variables:
+
+      LINTAI_MAX_LLM_TOKENS      (int, default 50 000)
+      LINTAI_MAX_LLM_COST_USD    (float, default 10.00)
+      LINTAI_MAX_LLM_REQUESTS    (int, default 500)
+    """
+
+    def __init__(self) -> None:
+        self._tok_used = 0
+        self._usd_used = Decimal("0")
+        self._req_used = 0
+        self._lock = threading.Lock()
+        self.reload()  # <─ read env the first time
+
+    def reload(self) -> None:
+        """(Re)read max_* limits from os.environ."""
+        self.max_tokens = int(os.getenv("LINTAI_MAX_LLM_TOKENS", "50000"))
+        self.max_cost_usd = Decimal(os.getenv("LINTAI_MAX_LLM_COST_USD", "10"))
+        self.max_requests = int(os.getenv("LINTAI_MAX_LLM_REQUESTS", "500"))
+
+    # ──────────────────────────────────────────────────────────────────────
+    #  public helpers
+    # ──────────────────────────────────────────────────────────────────────
+    def allow(self, est_prompt_tok: int, est_completion_tok: int, model: str) -> bool:
+        """Return True if the *estimate* would stay within budget."""
+        est_cost = _usd_for_tokens(est_prompt_tok + est_completion_tok, model)
+        with self._lock:
+            if (
+                self._tok_used + est_prompt_tok + est_completion_tok > self.max_tokens
+                or self._usd_used + est_cost > self.max_cost_usd
+                or self._req_used + 1 > self.max_requests
+            ):
+                return False
+            return True
+
+    def commit(
+        self,
+        prompt_tok: int,
+        completion_tok: int,
+        model: str,
+        real_cost_usd: Optional[Decimal] = None,
+    ) -> None:
+        """Record *actual* usage once a call returns."""
+        with self._lock:
+            self._tok_used += prompt_tok + completion_tok
+            self._usd_used += (
+                real_cost_usd
+                if real_cost_usd is not None
+                else _usd_for_tokens(prompt_tok + completion_tok, model)
+            )
+            self._req_used += 1
+
+    # handy wrapper – useful if you need manual guard outside the client
+    @contextmanager
+    def guard(self, est_prompt_tok: int, est_completion_tok: int, model: str):
+        ok = self.allow(est_prompt_tok, est_completion_tok, model)
+        yield ok
+        # detectors don’t commit – only the LLM client does afterwards.
+
+    # diagnostic
+    def snapshot(self) -> dict:
+        with self._lock:
+            return {
+                "tokens_used": self._tok_used,
+                "usd_used": float(self._usd_used),
+                "requests": self._req_used,
+                "limits": {
+                    "tokens": self.max_tokens,
+                    "usd": float(self.max_cost_usd),
+                    "requests": self.max_requests,
+                },
+            }
+
+
+# ---- module-level singleton -------------------------------------------------
+manager = BudgetManager()

--- a/lintai/llm/dummy.py
+++ b/lintai/llm/dummy.py
@@ -14,7 +14,7 @@ def create():
     class _Dummy(LLMClient):
         is_dummy = True
 
-        def ask(self, prompt, **kw):
+        def ask(self, prompt, max_tokens: int = 256, **kw):
             return _OFFLINE_JSON
 
     return _Dummy()

--- a/lintai/llm/errors.py
+++ b/lintai/llm/errors.py
@@ -1,0 +1,2 @@
+class BudgetExceededError(RuntimeError):
+    """Raised when the global LLM token / cost budget is exceeded."""

--- a/lintai/llm/token_util.py
+++ b/lintai/llm/token_util.py
@@ -1,0 +1,48 @@
+# lintai/llm/token_util.py
+from __future__ import annotations
+import logging
+
+log = logging.getLogger(__name__)
+
+# optional dependency – fall back gracefully
+try:
+    import tiktoken
+except ModuleNotFoundError:  # pragma: no cover
+    tiktoken = None
+
+_CL100K = None
+if tiktoken:
+    try:
+        _CL100K = tiktoken.get_encoding("cl100k_base")
+    except Exception:  # pragma: no cover
+        pass
+
+
+def estimate_tokens(text: str, model_hint: str | None = None) -> int:
+    """
+    Best-effort token estimator.
+
+    1.  If *tiktoken* is available & knows the model, use that.
+    2.  Else fall back to `cl100k_base` (handles GPT-4/-3.5 roughly).
+    3.  Else len(text) // 4 heuristic.
+    """
+    if not tiktoken:
+        return max(1, len(text) // 4)
+
+    try:
+        enc = (
+            tiktoken.encoding_for_model(model_hint) if model_hint else None  # fast path
+        )
+    except KeyError:
+        enc = None
+
+    if not enc:
+        enc = _CL100K
+
+    if enc:
+        try:
+            return len(enc.encode(text))
+        except Exception:  # defensive
+            pass
+
+    return max(1, len(text) // 4)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "networkx>=3.2",
     "python-dotenv>=1.0",
     "pathspec",
+    "tiktoken",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -33,7 +33,8 @@ def test_dsl_rule_hits(tmp_path):
     assert lines, f"Empty output: stderr={result.stderr!r}"
 
     try:
-        findings = json.loads(result.stdout)
+        result_obj = json.loads(result.stdout)
+        findings = result_obj["findings"]
     except Exception as e:
         pytest.fail(f"Could not parse JSON from output:\n{result.stdout}\nError: {e}")
 

--- a/tests/test_llm_detector.py
+++ b/tests/test_llm_detector.py
@@ -16,6 +16,7 @@ def test_llm_detector_offline(tmp_path, monkeypatch):
     result = subprocess.run(
         ["lintai", "scan", str(src)], capture_output=True, text=True, check=True
     )
-    findings = json.loads(result.stdout.strip().splitlines()[-1])
+    result_obj = json.loads(result.stdout)
+    findings = result_obj["findings"]
     # dummy provider returns no JSON → detector yields nothing
     assert not findings


### PR DESCRIPTION
This PR adds a built-in LLM usage budget to the Lintai CLI tool, ensuring the number of tokens, requests, and cost incurred by detectors remains within safe, configurable bounds.

### Key features:
- New `budget.py` manager that enforces:
  - Max tokens (`LINTAI_MAX_LLM_TOKENS`)
  - Max dollar cost (`LINTAI_MAX_LLM_COST_USD`)
  - Max LLM requests (`LINTAI_MAX_LLM_REQUESTS`)
- Budget usage report is now appended to scan output (`llm_usage`)
- `LLMClient` subclasses (OpenAI, Azure, Anthropic, Gemini, Cohere) updated to support budget checks
- CLI `--output` flag now supports writing full JSON (stdout by default)
- `.env` values respected (but not overriding explicit env vars) via `dotenv.load_dotenv(..., override=False)`
- `budget.manager.reload()` allows reloading limits after loading `.env`
- All tests pass with `pytest` including LLM dummy provider mode